### PR TITLE
feat: Implement banner override for YouTube thumbnails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .next
 node_modules
 package-lock.json
+dev_server.log

--- a/dev_server.log
+++ b/dev_server.log
@@ -1,3 +1,0 @@
-
-> iandouglas736-portfolio@0.1.0 dev
-> next dev

--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -46,6 +46,7 @@ const ContentCard = ({ item, className = '' }: ContentCardProps) => {
         url={item.url}
         title={item.title}
         className="w-full h-full"
+        banner={item.banner}
       />
     );
   } else if (item.banner && 'abstract' in item && item.abstract) {

--- a/src/components/YouTubeEmbed.tsx
+++ b/src/components/YouTubeEmbed.tsx
@@ -8,9 +8,10 @@ interface YouTubeEmbedProps {
   url: string;
   title: string;
   className?: string;
+  banner?: string;
 }
 
-const YouTubeEmbed = ({ url, title, className = '' }: YouTubeEmbedProps) => {
+const YouTubeEmbed = ({ url, title, className = '', banner }: YouTubeEmbedProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const videoId = getYouTubeVideoId(url);
 
@@ -22,7 +23,7 @@ const YouTubeEmbed = ({ url, title, className = '' }: YouTubeEmbedProps) => {
     );
   }
 
-  const thumbnailUrl = `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`;
+  const thumbnailUrl = banner ? `/logos/${banner}` : `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`;
 
   const openModal = () => setIsModalOpen(true);
   const closeModal = () => setIsModalOpen(false);


### PR DESCRIPTION
This change introduces the ability to override the default YouTube thumbnail with a local banner image.

The `YouTubeEmbed` component now accepts an optional `banner` prop. If a `banner` is provided, it will be used as the thumbnail image. Otherwise, the component will fall back to the default YouTube thumbnail.

The `ContentCard` component has been updated to pass the `banner` prop to the `YouTubeEmbed` component when a banner is available for a recorded talk.

The `dev_server.log` file has been added to `.gitignore` to prevent it from being committed in the future.